### PR TITLE
Move Gut from bitbucket to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For installation instructions, read [INSTALL.md](https://github.com/Calinou/awes
 - [GodotTIE](https://github.com/henriquelalves/GodotTIE) - Text Interface Engine to control text output (like in a RPG dialogue)
 - [Grass Plugin](https://github.com/marcosbitetti/grass_plugin_4_godot) - A plugin to handle huge amount of grass, foliages and other vegetations
 - [gterm](https://github.com/TeddyDD/gterm) - GUI Control that draws something similar to \*nix terminal emulators
-- [GUT](https://bitbucket.org/bitwes/gut/overview) - Utility for writing unit tests in GDScript.
+- [GUT](https://github.com/bitwes/Gut) - Utility for writing unit tests in GDScript.
 - [Heightmap](https://gist.github.com/TheHX/94a83dea1a0f932d5805) - Make an heightmap into terrain.
 - [OpenClipArt Store](https://github.com/vinod8990/godot_plugins/tree/master/OpenClipArt_Store) - Lets you integrate OpenClipArt assets easily, with a browser.
 - [Polygon Merge](https://github.com/ScyDev/Godot-Scripts) - Merge polygons.


### PR DESCRIPTION
I moved the repo from bitbucket to github.  This PR updates the URL for Gut.
