### PR TITLE
Update the Emacs editor support link

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ A curated list of [free/libre](https://www.gnu.org/philosophy/free-sw.html) game
 *Add-ons for text editors that implement GDScript support.*
 
 - [Atom](https://atom.io/packages/lang-gdscript) - Syntax highlighting.
-- [Emacs](https://github.com/francogarcia/godot-gdscript.el) - Syntax highlighting, indentation and autocompletion.
+- [Emacs](https://github.com/GDQuest/emacs-gdscript-mode) - Syntax highlighting, code folding, indentation and autocompletion.
 - [Geany](https://github.com/haimat/GDScript-Geany) - Syntax highlighting.
 - [Gedit](https://github.com/haimat/GDScript-gedit) - Syntax highlighting.
 - [IntelliJ IDEA](https://github.com/exigow/intellij-gdscript) - Syntax highlighting and autocompletion.


### PR DESCRIPTION
We created and maintain a new package for gdscript support in Emacs, that's now on the melpa archive (plugins that can be installed straight from Emacs). Franco, the author of the previous package, already contributed to it too, along with some other persons. Our new mode is up to date, has more features, is supported in Doom Emacs and Spacemacs...