### PR TITLE
Add Voxel-Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [Scatter](https://github.com/HungryProton/scatter) - Randomly fill an area with props or other scenes.
 - [UI Design Tool](https://github.com/imjp94/UIDesignTool) - Intuitive design workflow for UIs in the editor.
 - [Volumetrics](https://github.com/SIsilicon/Godot-Volumetrics-Plugin) - Voxel-based volumetric lighting and fog plugin.
+- [Voxel-Core](https://github.com/ClarkThyLord/Voxel-Core) - GDScript voxel plugin for creating, importing and editing voxel content in-engine and in-game
 - [VPainter](https://github.com/tomankirilov/VPainter) - 3D vertex painting plugin.
 - [Waterways](https://github.com/Arnklit/WaterGenGodot) - Tool to generate river meshes with flow and foam maps based on Bézier curves.
 - [Yume Visual Novel Editor](https://github.com/yumedev40/Yume-Visual-Novel-Editor) - An integrated editor for creating visual novel games.


### PR DESCRIPTION
Hello, wanted to add my recently reworked [Voxel-Core](https://github.com/ClarkThyLord/Voxel-Core) plugin, it's a voxel plugin that I made in 100% GDScript and it's ready to be used in your guys' projects 😄 

## Why Voxel-Core?
- Create, import and edit voxel content in-engine and in-game
- Runs anywhere Godot does (e.g. desktop, web, mobile, etc.)
- Great for voxel objects (e.g. characters, creatures, props, etc.)
- Designed to be easily extended, modify and expand Voxel-Core to meet your needs

# [Example Video](https://youtu.be/cnHA7uZahp8)