### PR TITLE
Revert Godot FPS Camera information about light cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 
 - [Crystal Bit Godot Game Template](https://github.com/crystal-bit/godot-game-template) - Opinionated game template. It includes continuous integration, scene loading with graphic transitions and game pause handling.
 - [First Person Starter](https://github.com/Whimfoome/godot-FirstPersonStarter) - Template with First Person Controller, easily adjustable from the Inspector.
-- [Godot First Person Camera](https://github.com/tavurth/godot-simple-fps-camera) - A simple FPS camera with jumping, movement and flashlight (light cookie).
+- [Godot First Person Camera](https://github.com/tavurth/godot-simple-fps-camera) - A simple FPS starter with jumping, movement, flashlight and a player character with animations.
 - [Godot Game Of Life](https://github.com/tavurth/godot-game-of-life) - Conway's *Game of life* using shaders.
 - [Minimum Game](https://github.com/benmarz/minimum_game) - Template top-down 2D pixel art game, with multiple rooms, a HUD, menus, and autosaving.
 - [Multiplayer First Person Shooter](https://github.com/blockspacer/Godot-3.2-Multiplayer-FPS) - Multiplayer first person shooter example project.


### PR DESCRIPTION
Due to https://github.com/godotengine/godot/issues/43827 I was unable to
implement my light cookie as I wanted.

The shadow from the directional light (sun) caused the light cookie to
be visible from different angles 😢

NOTE: It appears emacs believes that `_something_` is more useful than `*something*` even though it has the same result. If you'd like I can revert those changes?