### PR TITLE
Add vpuppr to projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [Material Maker](https://github.com/RodZill4/material-maker) - Create PBR materials procedurally (similar to Substance Designer).
 - [Pixelorama](https://github.com/Orama-Interactive/Pixelorama) - 2D pixel art editor.
 - [ProtonGraph](https://github.com/protongraph/protongraph) - Node-based tool for procedural content creation. Like visual scripting, but for 3D model generation (needs custom engine modules).
+- [vpuppr](https://github.com/virtual-puppet-project/vpuppr) - A cross-platform VTuber application with mulitple tracking backends.
 
 ## Templates
 


### PR DESCRIPTION
Adds [Virtual Puppet Project (vpuppr)](https://github.com/virtual-puppet-project/vpuppr) to the list of non-game projects.