### PR TITLE
Add zfoo game server framework for godot

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,4 +402,4 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [RetroPie Godot Game Engine "Emulator"](https://github.com/hiulit/RetroPie-Godot-Game-Engine-Emulator) - A scriptmodule to install a Godot "emulator" for RetroPie.
 - [strip-to-frames.pl](https://github.com/adolson/godot-stuff/blob/master/strip-to-frames.pl) - Perl script to split a grid spritesheet image into numbered individual frame files.
 - [Godot Package Manager](https://github.com/you-win/godot-package-manager) - Package manager for Godot using npm.
-- [zfoo](https://github.com/zfoo-project/zfoo) -  java game server framework for godot include GdScript serialization and deserialization.
+- [zfoo](https://github.com/zfoo-project/zfoo) - Java game server framework for Godot, including GDScript serialization and deserialization.

--- a/README.md
+++ b/README.md
@@ -402,3 +402,4 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [RetroPie Godot Game Engine "Emulator"](https://github.com/hiulit/RetroPie-Godot-Game-Engine-Emulator) - A scriptmodule to install a Godot "emulator" for RetroPie.
 - [strip-to-frames.pl](https://github.com/adolson/godot-stuff/blob/master/strip-to-frames.pl) - Perl script to split a grid spritesheet image into numbered individual frame files.
 - [Godot Package Manager](https://github.com/you-win/godot-package-manager) - Package manager for Godot using npm.
+- [zfoo](https://github.com/zfoo-project/zfoo) -  java game server framework for godot include GdScript serialization and deserialization.


### PR DESCRIPTION
an open source java game server framework for godot include GdScript serialization and deserialization.