### PR TITLE
Add AnimatedShape2D plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,10 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [Tiled importer](https://github.com/vnen/godot-tiled-importer) - Import maps from [Tiled](https://www.mapeditor.org/) (Godot 3.x).
 - [TileSet Builder](https://github.com/HeavenMercy/TileSet-Builder-Godot-Plugin) - Quickly build tilesets with style (Godot 3.x).
 
+#### Godot 4.2+
+
+- [AnimatedShape2D](https://github.com/Goutte/godot-addon-animated-shape-2d) - Animate a CollisionShape2D along with the frames of an AnimatedSprite2D.
+
 #### Godot 3.2+
 
 - [AntialiasedLine2D](https://github.com/godot-extended-libraries/godot-antialiased-line2d) - Higher-quality antialiased Line2D and Polygon2D drawing compared to the default Godot implementation (GLES3 + GLES2, all platforms).


### PR DESCRIPTION
> Disclaimer: I'm the author of this plugin.  I use it with great satisfaction.

The `AnimatedShape2D` allows you to quickly configure different collision shapes for each frame of each animation of an `AnimatedSprite2D`.

It comes with an Editor:

![screenshot_02](https://github.com/godotengine/awesome-godot/assets/592545/d595e7ea-8ea0-4254-bbd2-5c08d71b532b)

> I think it's awesome, but I'm biased.  I'll let _you_ judge.  ;)