### PR TITLE
Remove "The Godot Report"

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,6 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [Godot Shaders](https://godotshaders.com/) - A community-driven shader library for the Godot game engine.
 - [Godotes](https://godotes.com/) - Weekly micro data analysis reports about the Godot engine and its ecosystem.
 - [Gotm.io](https://gotm.io/about) - A website for hosting HTML5 games that were made in Godot.
-- [The Godot Report](https://www.thegodotreport.com/) - A newsletter with news, tutorials, game and demo releases and more.
 
 ## Other
 


### PR DESCRIPTION
Domain redirects to https://error.ghost.org/ with the error message "Failed to resolve DNS path for this host"

Last report was published in November 2022: https://nitter.unixfox.eu/TheGodotReport