### PR TITLE
Add godot-solana-sdk plugin to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 #### Godot 4.2+
 
 - [AnimatedShape2D](https://github.com/Goutte/godot-addon-animated-shape-2d) - Animate a CollisionShape2D along with the frames of an AnimatedSprite2D.
+- [Godot Solana SDK](https://github.com/Virus-Axel/godot-solana-sdk) - Add Solana blockchain support to your Godot projects.
 - [LimboAI](https://github.com/limbonaut/limboai) - Behavior trees and state machines. Comes with editor, visual debugger, comprehensive demo and tutorial.
 
 #### Godot 3.2+


### PR DESCRIPTION
I would like to add my godot-solana-sdk plugin to the list.