### PR TITLE
Add Kaleidoscope to Demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 
 *Demos to learn GDScript, its concepts, and various game features.*
 
+#### Godot 4.0
+
+- [Kaleidoscope](https://github.com/Elesh-Norn/kaleidoscope) - A demo for interactive shaders in Godot
+
 #### Godot 3.2+
 
 - [Godot Demo Projects](https://github.com/godotengine/godot-demo-projects) - Official Godot demo projects (everything except the TPS demo).

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 
 *Demos to learn GDScript, its concepts, and various game features.*
 
-#### Godot 4.0
+#### Godot 4.x
 
 - [Kaleidoscope](https://github.com/Elesh-Norn/kaleidoscope) - A demo for interactive shaders in Godot
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 
 #### Godot 4.x
 
-- [Kaleidoscope](https://github.com/Elesh-Norn/kaleidoscope) - A demo for interactive shaders in Godot
+- [Kaleidoscope](https://github.com/Elesh-Norn/kaleidoscope) - A demo for interactive shaders in Godot.
 
 #### Godot 3.2+
 


### PR DESCRIPTION
Adds a simple Godot 4 demo showcasing (interactive) shaders using Godot's shading language