### PR TITLE
Added theme section split between engine and existing syntax themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [Themes](#themes)
   - [Engine themes](#engine-themes)
   - [Syntax themes](#syntax-themes)
-<!-- - [Godot script editor syntax themes](#godot-script-editor-syntax-themes) -->
 - [Unofficial Godot builds](#unofficial-godot-builds)
 - [Bash scripts](#bash-scripts)
 - [Websites](#websites)
@@ -399,8 +398,8 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 
 *Alternative themes for the entire Godot engine editor.*
 
-- [Godot Minimal Theme](https://github.com/passivestar/godot-minimal-theme) - A theme that aims to correct odd spacing and formatting in the default Godot theme without changing the overall look and feel.
 - [Catppuccin Theme](https://github.com/catppuccin/godot) - A soothing pastel theme offered in four different flavors.
+- [Godot Minimal Theme](https://github.com/passivestar/godot-minimal-theme) - A theme that aims to correct odd spacing and formatting in the default Godot theme without changing the overall look and feel.
 
 ### Syntax themes
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [Plugins and scripts](#plugins-and-scripts)
 - [Modules](#modules)
 - [GDScript/C# editor support](#gdscriptc-editor-support)
-- [Godot script editor syntax themes](#godot-script-editor-syntax-themes)
+- [Themes](#themes)
+  - [Engine themes](#engine-themes)
+  - [Syntax themes](#syntax-themes)
+<!-- - [Godot script editor syntax themes](#godot-script-editor-syntax-themes) -->
 - [Unofficial Godot builds](#unofficial-godot-builds)
 - [Bash scripts](#bash-scripts)
 - [Websites](#websites)
@@ -390,7 +393,16 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
   - [GUT Visual Studio Code Extension](https://github.com/bitwes/gut-extension) - Run GUT framework unit/integration tests directly from the Visual Studio Code Editors.
   - [gdformat Visual Studio Code Extension](https://marketplace.visualstudio.com/items?itemName=Razoric.gdscript-toolkit-formatter) - Formatter for GDScript in Visual Studio Code.
 
-## Godot script editor syntax themes
+## Themes
+
+### Engine themes
+
+*Alternative themes for the entire Godot engine editor.*
+
+- [Godot Minimal Theme](https://github.com/passivestar/godot-minimal-theme) - A theme that aims to correct odd spacing and formatting in the default Godot theme without changing the overall look and feel.
+- [Catppuccin Theme](https://github.com/catppuccin/godot) - A soothing pastel theme offered in four different flavors.
+
+### Syntax themes
 
 *Alternative themes for the built-in script editor.*
 


### PR DESCRIPTION
With the theming capabilities expanding with every release, it seems prudent to add a section that offers editor-wide themes in addition to the code syntax themes. This PR adds a Theme section with subsections for editor themes and syntax themes, with the existing items under the previous "Godot script editor syntax themes" section placed under the syntax themes subsection.