### PR TITLE
Remove godotes from the list of websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,6 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 
 - [Godot Asset Library](https://godotengine.org/asset-library/asset) - Official Godot Asset Library. Includes user-created games, projects, templates, demos, tutorials, plugins, and scripts.
 - [Godot Shaders](https://godotshaders.com/) - A community-driven shader library for the Godot game engine.
-- [Godotes](https://godotes.com/) - Weekly micro data analysis reports about the Godot engine and its ecosystem.
 
 ## Other
 


### PR DESCRIPTION
The [website](https://godotes.com) is dead and is up for sale 😭
