### PR TITLE
Add Godot YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [godot-jolt](https://github.com/godot-jolt/godot-jolt) - Allows you to use the [Jolt Physics Engine](https://github.com/jrouwe/JoltPhysics).
 - [godot-luaAPI](https://github.com/WeaselGames/godot_luaAPI) - Module for creating sandboxed modding APIs with Lua. *(Godot 3 and 4)*
 - [godot-rapier-2d](https://github.com/appsinacup/godot-rapier-2d) - A 2D [Rapier](https://github.com/dimforge/rapier) physics server for Godot.
+- [Godot YAML](https://github.com/fimbul-works/godot-yaml) - High-performance YAML parser/serializer with full type support and custom class serialization.
 - [Keyring](https://github.com/shomykohai/godot-keyring) - Utility to interact with the OS keyring to store credentials.
 - [Texture Packer](https://github.com/Relintai/texture_packer) - Tools to layer, pack, and merge textures at runtime. *(Godot 3 and 4)*
 - [Voxelman](https://github.com/Relintai/voxelman) - A voxel engine with more focus on editor integration, gameplay-related features, and extendability. *(Godot 3 and 4)*


### PR DESCRIPTION
I would like to add my GDExtension for Godot 4.3 and higher that integrates the YAML file format into the engine.

It can serializing/deserializing _almost_ all native variant types along with custom classes, and enables custom styling of the documents.