### PR TITLE
[Add] Neovim plugin: godotdev.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [JetBrains Rider (C#)](https://github.com/JetBrains/godot-support) - Syntax highlighting, autocompletion and run configurations.
 - [Kakoune](https://github.com/Skytrias/gdscript-kak) - Syntax highlighting.
 - [GNU Nano](https://github.com/GodotID/nano-gdscript) - Syntax highlighting.
+- [Neovim](https://github.com/Mathijs-Bakker/godotdev.nvim) - A batteries-included Neovim plugin for Godot 4.x game development. Use Neovim as a fully featured external editor for Godot, with minimal setup.
 - [Sublime Text](https://github.com/beefsack/GDScript-sublime) - Syntax highlighting.
 - [Vim](https://github.com/habamax/vim-godot) - Syntax highlighting, autocompletion and linting using the LSP server provided by the Godot editor. Also supports the Godot shader language.
 - Visual Studio Code


### PR DESCRIPTION
## This PR adds:

**`- Neovim`** to the `Gdscript/editors section`, with a link to `godotdev.nvim`.

### What is godotdev.nvim?

**godotdev.nvim** is a batteries-included Neovim plugin for Godot 4.x game development. It allows you to use Neovim as a fully featured external editor for Godot, with minimal setup.

**The plugin provides:**

LSP support for GDScript and Godot shaders (.gdshader files)
- Debugging via nvim-dap for GDScript
- Treesitter syntax highlighting for Godot shader files
- Automatic formatting of .gd files using gdformat
- Optional C# support including LSP, debugging, and tooling
- Built-in health checks to verify environment, dependencies, and editor integration

While it is possible to configure Neovim manually for Godot development, this plugin simplifies setup and ensures a consistent, cross-platform workflow. It automatically configures LSP, debugging, formatting, and environment checks, so you can focus on writing game code rather than troubleshooting editor setup.