### PR TITLE
Add Godot Doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [func_godot](https://github.com/func-godot/func_godot_plugin) - Import maps using the [Quake MAP file format](https://quakewiki.org/wiki/Quake_Map_Format), commonly made using an editor such as [TrenchBroom](https://trenchbroom.github.io/).
 - [GDGIFExporter](https://github.com/jegor377/godot-gdgifexporter) - GIF exporter made entirely in GDScript.
 - [GdUnit4](https://github.com/MikeSchulze/gdUnit4) - Godot Unit Testing Framework.
+- [Godot Doctor](https://github.com/codevogel/godot_doctor) - A powerful validation plugin for Godot that catches errors in scenes and resources before they reach runtime. Also supports type validation for `PackedScene`s.
 - [Godot Google Play Game Services](https://github.com/Iakobs/godot-play-game-services) - Integrate Google Play Games Services in your Godot game.
 - [godot-ink](https://github.com/paulloz/godot-ink) - A C# (Mono) plugin to integrate stories writen in [ink](https://github.com/inkle/ink), a scripting language for writing interactive narrative.
 - [Godot NDI](https://github.com/unvermuthet/godot-ndi) - Integrates the NDI® SDK with Godot.


### PR DESCRIPTION
Adds [Godot Doctor](https://github.com/codevogel/godot_doctor) to the list.

- [x] Projects must have a [free/libre](https://gnu.org/licenses/license-list.html) license. If they lack a license, get to the original maintainer and ask them to add a license.
    - MIT licensed. Should be named differently according to the GNU license list, but the asset library accepts MIT.
- [x]     The scripts, add-ons or plugins must be useful in a project.
    - Usefulness explained in the original repository. Has 22 stars in a day, so it must be useful to some at least :)
- [x]     Follow the existing style.
    - Adheres to the style
- [x]     Sort in alphabetical order.
    - Is in alphabetical order
- [x]     Categorize by newest compatible Godot version.
    - Minimum version is 4.0
- [x]     Projects related to cryptocurrency or NFT integrations are not allowed, for reasons including (but not limited to) the risk of scams.
    - Not crypto related.