### PR TITLE
Add Script-IDE as plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [Roommate](https://github.com/hoork/roommate) - 3D level builder tool with focus on creating indoors environment and automation.
 - [Scene Library](https://github.com/4d49/scene-library) - A tool for organizing Godot scenes with efficiency.
 - [Scene Manager](https://github.com/glass-brick/Scene-Manager) - Make nice and customizable scene transitions in one line of code. *(Godot 3 and 4)*
-- [Script-IDE](https://github.com/Maran23/script-ide) - Transforms the Script UI into an IDE like UI. Multiline Tabs, Improved Outline, Quick Open and Override, Enhanced keyboard navigation.
+- [Script-IDE](https://github.com/Maran23/script-ide) - Transforms the script editor into an IDE-like UI. Multiline tabs, improved outline, quick open and override, enhanced keyboard navigation.
 - [Shaker](https://github.com/Eneskp3441/Shaker) - Plugin that adds shaking and emitters for cameras, nodes or any property in 2D and 3D.
 - [SignalVisualizer](https://github.com/Ericdowney/SignalVisualizer) - Displays the current scene's signals and connections in a easy to read graph and tree dock.
 - [Simplified Flight Simulation library](https://github.com/fbcosentino/godot-simplified-flightsim) - A library that helps you create a simple airplane/helicopter/spaceship flight simulator. *(Godot 3 and 4)*

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [Roommate](https://github.com/hoork/roommate) - 3D level builder tool with focus on creating indoors environment and automation.
 - [Scene Library](https://github.com/4d49/scene-library) - A tool for organizing Godot scenes with efficiency.
 - [Scene Manager](https://github.com/glass-brick/Scene-Manager) - Make nice and customizable scene transitions in one line of code. *(Godot 3 and 4)*
+- [Script-IDE](https://github.com/Maran23/script-ide) - Transforms the Script UI into an IDE like UI. Multiline Tabs, Improved Outline, Quick Open and Override, Enhanced keyboard navigation.
 - [Shaker](https://github.com/Eneskp3441/Shaker) - Plugin that adds shaking and emitters for cameras, nodes or any property in 2D and 3D.
 - [SignalVisualizer](https://github.com/Ericdowney/SignalVisualizer) - Displays the current scene's signals and connections in a easy to read graph and tree dock.
 - [Simplified Flight Simulation library](https://github.com/fbcosentino/godot-simplified-flightsim) - A library that helps you create a simple airplane/helicopter/spaceship flight simulator. *(Godot 3 and 4)*


### PR DESCRIPTION
I'd like to add my Godot 4 plugin: [Script-IDE](https://github.com/Maran23/script-ide).

Transforms the Script UI into an IDE like UI. Multiline Tabs, Improved Outline, Quick Open and Override, Enhanced keyboard navigation. 

It is liked a lot in the Godot Community, so I think it is worth to add here! :)