### PR TITLE
Add external editor themes section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,12 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [Godot syntax themes](https://github.com/godotengine/godot-syntax-themes) - 13 syntax themes including Ayu Mirage, Darcula, Gruvbox Dark, Monokai, One Dark, Solarized, and more.
 - [Syntax themes by Geequlim](https://github.com/Geequlim/godot-themes/tree/master/syntax) - Chester, Google Code Light and Monokai.
 
+### External editor themes
+
+*Alternative themes with the trusted Godot editor's colors for external tools.*
+- [NeoVim - godot_color_theme](https://github.com/voylin/godot_color_theme/tree/master/lua).
+- [Alacritty - godot_color_theme](https://github.com/voylin/godot_color_theme/tree/master/alacritty).
+
 ## Unofficial Godot builds
 
 *Those builds will let you use recent versions of Godot Git, but they may be less stable than official ones – use at your own risk.*

--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 ### External editor themes
 
 *Alternative themes with the trusted Godot editor's colors for external tools.*
+
 - [NeoVim - godot_color_theme](https://github.com/voylin/godot_color_theme/tree/master/lua).
 - [Alacritty - godot_color_theme](https://github.com/voylin/godot_color_theme/tree/master/alacritty).
 

--- a/README.md
+++ b/README.md
@@ -446,8 +446,9 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 
 *Alternative themes with the trusted Godot editor's colors for external tools.*
 
-- [NeoVim - godot_color_theme](https://github.com/voylin/godot_color_theme/tree/master/lua).
-- [Alacritty - godot_color_theme](https://github.com/voylin/godot_color_theme/tree/master/alacritty).
+- [Alacritty](https://github.com/voylin/godot_color_theme/tree/master/alacritty)
+- [NeoVim](https://github.com/voylin/godot_color_theme/tree/master/lua)
+- [Visual Studio Code](https://github.com/ryanabx/godot-vscode-theme)
 
 ## Unofficial Godot builds
 


### PR DESCRIPTION
Added section for external editor themes with links to a dynamic color theme with Godot's colors for NeoVim and a file which generates the color scheme according to Godot's colors for Alacritty.

License is MIT and it makes moving between NeoVim and Godot seamless as they look identical in colors. Even if you adjusted the base color, accent color, and contrast, you can easily update those values to get the desired result as in to look (nearly) identical to the color scheme of Godot.

The color scheme is compatible with Godot 3 and Godot 4 (with the new theme/colors) as it uses the same color logic of the editor.

Let me know if I need to adjust anything, I created a new section as I thought it might be good to have a section to make the tools you use similarly themed to Godot's editor theme.