### PR TITLE
Add Godot Gaussian Splatting plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [Gedis](https://github.com/NodotProject/Gedis) - In-memory, Redis-like key-value store for Godot.
 - [GedisQueue](https://github.com/NodotProject/GedisQueue) - A comprehensive job queue system for Godot, backed by Gedis.
 - [Godot Doctor](https://github.com/codevogel/godot_doctor) - A powerful validation plugin for Godot that catches errors in scenes and resources before they reach runtime. Also supports type validation for `PackedScene`s.
+- [Godot Gaussian Splatting](https://github.com/ReconWorldLab/godot-gaussian-splatting) - Real-time 3D Gaussian Splatting rendering plugin for Godot 4.4+.
 - [Godot Google Play Game Services](https://github.com/Iakobs/godot-play-game-services) - Integrate Google Play Games Services in your Godot game.
 - [godot-ink](https://github.com/paulloz/godot-ink) - A C# (Mono) plugin to integrate stories writen in [ink](https://github.com/inkle/ink), a scripting language for writing interactive narrative.
 - [Godot NDI](https://github.com/unvermuthet/godot-ndi) - Integrates the NDI® SDK with Godot.


### PR DESCRIPTION
Add Godot Gaussian Splatting, a Godot 4.4+ plugin for real-time 3D Gaussian Splatting rendering.

This repository contains installation instructions and plugin files under ddons/gdgs.