### PR TITLE
Add Godot Awesome Scientific to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,3 +495,4 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [ShipThis](https://github.com/shipth-is/cli) - CLI to build and publish Godot mobile games to the App Store and Google Play.
 - [strip-to-frames.pl](https://github.com/adolson/godot-stuff/blob/master/strip-to-frames.pl) - Perl script to split a grid spritesheet image into numbered individual frame files.
 - [zfoo](https://github.com/zfoo-project/zfoo) - Java game server framework for Godot, including GDScript serialization and deserialization.
+- [Godot Awesome Scientific](https://github.com/Ivorforce/Awesome-Godot-Scientific/) - A community-curated list of Godot software that provides methods for scientific methods, machine learning, and hyperoptimized computation.

--- a/README.md
+++ b/README.md
@@ -495,4 +495,18 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [ShipThis](https://github.com/shipth-is/cli) - CLI to build and publish Godot mobile games to the App Store and Google Play.
 - [strip-to-frames.pl](https://github.com/adolson/godot-stuff/blob/master/strip-to-frames.pl) - Perl script to split a grid spritesheet image into numbered individual frame files.
 - [zfoo](https://github.com/zfoo-project/zfoo) - Java game server framework for Godot, including GDScript serialization and deserialization.
-- [Godot Awesome Scientific](https://github.com/Ivorforce/Awesome-Godot-Scientific/) - A community-curated list of Godot software that provides methods for scientific methods, machine learning, and hyperoptimized computation.
+- [asdf-godot](https://github.com/mkungla/asdf-godot) - Godot plugin for the [asdf version manager](https://asdf-vm.com).
+- [codetranslator](https://github.com/HaSa1002/codetranslator) - Translates GDScript to C# (WIP).
+- [gd2cs.py](https://github.com/kiriri/gd2cs.py) - Python script that converts GDScript code to C# (WIP).
+- [gdvm](https://gdvm.io) ([GitHub](https://github.com/adalinesimonian/gdvm)) - Command-line version manager for Godot Engine, allowing you to easily install and switch between different Godot versions on Windows, macOS, and Linux (x86, x86_64, and ARM64).
+- [godot-actions](https://github.com/bend-n/godot-actions) - Composite actions for exporting, setting up, and pushing Godot projects to itch.io through Github Actions.
+- [godot-ci](https://github.com/aBARICHELLO/godot-ci) - Docker image to export Godot games through CI. Includes GitLab CI script example.
+- [godot-gdscript-toolkit](https://github.com/Scony/godot-gdscript-toolkit) - Independent set of command line tools for working with GDScript - parser, linter and formatter.
+- [godot-launcher](https://github.com/sebastianoboem/godot-launcher) - A desktop application built with Python that simplifies the Godot Engine development environment management.
+- [Godot Awesome Scientific](https://github.com/Ivorforce/Awesome-Godot-Scientific/) - Community-curated list of Godot software that provides methods for scientific methods, machine learning, and hyperoptimized computation.
+- [Godot Package Manager](https://github.com/you-win/godot-package-manager) - Package manager for Godot using npm.
+- [`gd-com` npm package](https://www.npmjs.com/package/@gd-com/utils) - Communicate with Godot clients using Node.js.
+- [RetroPie Godot Game Engine "Emulator"](https://github.com/hiulit/RetroPie-Godot-Game-Engine-Emulator) - A scriptmodule to install a Godot "emulator" for RetroPie.
+- [ShipThis](https://github.com/shipth-is/cli) - CLI to build and publish Godot mobile games to the App Store and Google Play.
+- [strip-to-frames.pl](https://github.com/adolson/godot-stuff/blob/master/strip-to-frames.pl) - Perl script to split a grid spritesheet image into numbered individual frame files.
+- [zfoo](https://github.com/zfoo-project/zfoo) - Java game server framework for Godot, including GDScript serialization and deserialization.


### PR DESCRIPTION
Here's the repo: https://github.com/Ivorforce/Awesome-Godot-Scientific/

Another approach would be to close my repo and integrate the changes here.
There are two main reasons why it is separate right now:

1. This is a very specific concern; often not useful to people making games, but rather to people experimenting in Godot.
2. There is advanced information there, such as the flow diagram, which might be too much for a generalized list like this one.

I think the simplest is to just link the repo. But feel free to challenge this / make alternative suggestions!
