### PR TITLE
Add Wick — MCP server for Godot

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [Lorien](https://github.com/mbrlabs/Lorien) - Infinite-canvas drawing/whiteboarding app for Windows, Linux and macOS. Supports drawing tablets and pressure sensitivity.
 - [Material Maker](https://github.com/RodZill4/material-maker) - Create PBR materials procedurally (similar to Substance Designer).
 - [Pixelorama](https://github.com/Orama-Interactive/Pixelorama) - 2D pixel art editor.
+- [Wick](https://github.com/buildepicshit/Wick) - Native C# MCP server connecting AI coding assistants to a running Godot editor. 53 tools for exception telemetry, scene inspection, C# analysis, builds, and GDScript validation.
 - [ProtonGraph](https://github.com/protongraph/protongraph) - Node-based tool for procedural content creation. Like visual scripting, but for 3D model generation (needs custom engine modules).
 
 #### Godot 3


### PR DESCRIPTION
Adds [Wick](https://github.com/buildepicshit/Wick) to the Projects > Godot 4 section.

Wick is a native C# Model Context Protocol (MCP) server that connects AI coding assistants (Claude, Cursor, Copilot, etc.) to a running Godot editor. 53 tools for exception telemetry, scene tree inspection, C# symbol navigation, build orchestration, and GDScript validation.

- .NET 10 / C# 14
- MIT licensed
- 219 tests, 0 warnings
- [v0.1.0 released](https://github.com/buildepicshit/Wick/releases/tag/v0.1.0)