### PR TITLE
Add cli-anything-godot to Other

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 *Other stuff.*
 
 - [asdf-godot](https://github.com/mkungla/asdf-godot) - Godot plugin for the [asdf version manager](https://asdf-vm.com).
+- [cli-anything-godot](https://github.com/lxistired/cli-anything-godot) - Agent-friendly command-line wrapper for Godot 4 that drives scenes, runs GDScript headlessly, exports projects, and dumps the engine API as JSON for LLMs and CI pipelines.
 - [codetranslator](https://github.com/HaSa1002/codetranslator) - Translates GDScript to C# (WIP).
 - [gd2cs.py](https://github.com/kiriri/gd2cs.py) - Python script that converts GDScript code to C# (WIP).
 - [gdvm](https://gdvm.io) ([GitHub](https://github.com/adalinesimonian/gdvm)) - Command-line version manager for Godot Engine, allowing you to easily install and switch between different Godot versions on Windows, macOS, and Linux (x86, x86_64, and ARM64).


### PR DESCRIPTION
Adds [cli-anything-godot](https://github.com/lxistired/cli-anything-godot) to the **Other** section.

### What it is
An agent-friendly command-line wrapper for Godot 4 — drives `.tscn` scenes, runs GDScript via `--headless`, exports projects, and dumps `ClassDB` as JSON. It complements (rather than competes with) the in-editor MCP/plugin ecosystem: this runs entirely outside the editor, so LLM agents and CI pipelines can work with Godot projects without an editor session open.

### Why it's useful
- Lets coding agents (Claude Code, Cursor, etc.) edit scenes and run scripts programmatically without piloting the editor UI
- Headless export + engine-API dump for CI (lint scripts against the real `ClassDB`, not stale stubs)
- Cross-platform (macOS / Linux / Windows), single `pip install -e .`

### Contributing guidelines check
- ✅ MIT license (free/libre)
- ✅ Useful in a Godot project (scripting/CI/agent workflow tool)
- ✅ Follows existing style (line under `Other → asdf-godot`, before `codetranslator`)
- ✅ Alphabetically sorted
- ✅ No crypto/NFT content