### PR TITLE
Add Godot Gaussian Splatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [Gedis](https://github.com/NodotProject/Gedis) - In-memory, Redis-like key-value store for Godot.
 - [GedisQueue](https://github.com/NodotProject/GedisQueue) - A comprehensive job queue system for Godot, backed by Gedis.
 - [Godot Doctor](https://github.com/codevogel/godot_doctor) - A powerful validation plugin for Godot that catches errors in scenes and resources before they reach runtime. Also supports type validation for `PackedScene`s.
+- [Godot Gaussian Splatting](https://github.com/ReconWorldLab/godot-gaussian-splatting) - Import and render 3D Gaussian Splatting assets in Godot 4.
 - [Godot Google Play Game Services](https://github.com/Iakobs/godot-play-game-services) - Integrate Google Play Games Services in your Godot game.
 - [godot-ink](https://github.com/paulloz/godot-ink) - A C# (Mono) plugin to integrate stories writen in [ink](https://github.com/inkle/ink), a scripting language for writing interactive narrative.
 - [Godot NDI](https://github.com/unvermuthet/godot-ndi) - Integrates the NDI® SDK with Godot.


### PR DESCRIPTION
This adds Godot Gaussian Splatting to the "Plugins and scripts" section for Godot 4.

- License: MIT
- Import and rendering support for 3D Gaussian Splatting assets
