### PR TITLE
Adding 2dog to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 
 #### Godot 4
 
+- [2dog](https://2dog.dev) - Run and Control Godot in .NET, create Unit Tests, custom developer and CI workflows using your existing .NET tools and IDEs.
 - [3D Auto Collision Generator](https://github.com/ThGnommy/godot_3d_auto_collision_generator) - Generate collision for multiple 3D objects in one click.
 - [AgonesSDK](https://github.com/AndreMicheletti/godot-agones-sdk) - Plugin to add [Agones](https://github.com/googleforgames/agones) SDK functionality to Godot.
 - [AnimatedShape2D](https://github.com/Goutte/godot-addon-animated-shape-2d) - Animate a CollisionShape2D along with the frames of an AnimatedSprite2D.

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 
 #### Godot 4
 
-- [2dog](https://2dog.dev) - Run and Control Godot in .NET, create Unit Tests, custom developer and CI workflows using your existing .NET tools and IDEs.
+- [2dog](https://2dog.dev) - Run and control Godot in .NET, create unit tests, custom developer and CI workflows using your existing .NET tools and IDEs.
 - [3D Auto Collision Generator](https://github.com/ThGnommy/godot_3d_auto_collision_generator) - Generate collision for multiple 3D objects in one click.
 - [AgonesSDK](https://github.com/AndreMicheletti/godot-agones-sdk) - Plugin to add [Agones](https://github.com/googleforgames/agones) SDK functionality to Godot.
 - [AnimatedShape2D](https://github.com/Goutte/godot-addon-animated-shape-2d) - Animate a CollisionShape2D along with the frames of an AnimatedSprite2D.


### PR DESCRIPTION
I would like my free&libre open source package / "module" 2dog to be listed in awesome-godot. It currently supports the latest Godot 4.6 and with the release of Godot 4.7 I will begin running multi-version support tracks.