### PR TITLE
Add Godot RISC-V build link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 *Those builds will let you use recent versions of Godot Git, but they may be less stable than official ones – use at your own risk.*
 
 - [bend-n's 2D builds](https://github.com/bend-n/godot-builds) - Godot builds [optimized for size](https://docs.godotengine.org/en/stable/engine_details/development/compiling/optimizing_for_size.html) with [these modules disabled](https://github.com/bend-n/godot-builds/blob/main/.github/2d-build-modules.py). Also includes misc non breaking patches.
+- [Godot RISC-V](https://gitee.com/openkylin/godot-riscv) - Godot built for the RISC‑V architecture.
 
 ## Bash scripts
 


### PR DESCRIPTION
This PR adds a community-maintained build of Godot for the RISC-V architecture to the "Unofficial Godot builds" section.

RISC-V is an open standard ISA gaining traction in the embedded and desktop space. 