### PR TITLE
Add Hex Strategy Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [GUT](https://github.com/bitwes/Gut) - Utility for writing unit tests in GDScript.
 - [HCoroutines](https://github.com/Inspiaaa/HCoroutines) - Powerful C# coroutine library for Godot.
 - [Health, HitBoxes, HurtBoxes, and HitScans](https://github.com/cluttered-code/godot-health-hitbox-hurtbox) - 2D and 3D Components to manage health, damage, and healing.
+- [Hex Strategy Map](https://github.com/JavierIslas/hex-strategy-map-free) - Hex grid foundation: coordinates (offset/cube), pathfinding (Dijkstra/A*), fog of war, rendering, camera.
 - [HTerrain](https://github.com/Zylann/godot_heightmap_plugin) - Heightmap-based terrain. Supports texture painting, colouring, holes, level of detail and grass. *(Godot 3 and 4)*
 - [Icon Explorer](https://kenyoni-software.github.io/godot-addons/addons/icon_explorer) - Browse and save icons from popular icon collections.
 - [Importality](https://github.com/nklbdev/godot-4-importality) - raster graphics and animations importers: Aseprite, Krita, Pencil2D, Piskel, Pixelorama and others.


### PR DESCRIPTION
Adds [Hex Strategy Map](https://github.com/JavierIslas/hex-strategy-map-free), a hex grid foundation plugin for Godot 4.6+: coordinates
  (offset/cube), pathfinding (Dijkstra and A*), 3-state fog of war, hex rendering with batch mode for large maps, and camera controls.

  - **License:** MIT
  - **Godot version:** 4.6+
  - **Asset Library:** https://godotengine.org/asset-library/asset/5136
  - **Tests:** 560+ unit tests via gdUnit4

  Inserted alphabetically in `Plugins and scripts → Godot 4`, between "Health, HitBoxes..." and "HTerrain".