### PR TITLE
Add P-and-p-editor to Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [Lorien](https://github.com/mbrlabs/Lorien) - Infinite-canvas drawing/whiteboarding app for Windows, Linux and macOS. Supports drawing tablets and pressure sensitivity.
 - [Material Maker](https://github.com/RodZill4/material-maker) - Create PBR materials procedurally (similar to Substance Designer).
 - [Pixelorama](https://github.com/Orama-Interactive/Pixelorama) - 2D pixel art editor.
+- [P-and-p-editor](https://github.com/Pig-and-pancakes-team/P-and-p-editor) - A minimal fantasy console and IDE built entirely in Godot 4
 - [ProtonGraph](https://github.com/protongraph/protongraph) - Node-based tool for procedural content creation. Like visual scripting, but for 3D model generation (needs custom engine modules).
 
 #### Godot 3


### PR DESCRIPTION
Hello! I would like to suggest my project for the Awesome Godot list.

P-and-p-editor — A minimal fantasy console and IDE built entirely in Godot 4.

Why it's cool:

Custom VM: It uses a virtual machine logic with a dedicated VRAM-like system based on PackedByteArray for high-performance pixel manipulation.

Built-in IDE: Includes a code editor (GDScript-based API), sprite editor, and map editor within a single environment.

Optimized Rendering: Features a custom rendering pipeline to mimic retro-console limitations while maintaining 60 FPS.

Open Source: Licensed under MIT.

I am an indie developer working solo on this project. My goal was to create a lightweight, "all-in-one" environment for people who love the constraints of retro-gaming (like PICO-8) but want to stay within the Godot ecosystem.