### PR TITLE
Addon: RPG Components 2D

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [godot-playfab](https://github.com/Structed/godot-playfab) - Use PlayFab as your game's cross-platform backend, with easy analytics.
 - [Godot Polygon 2D Fracture](https://github.com/SoloByte/godot-polygon2d-fracture) - Two simple scripts for fracturing and cutting polygons.
 - [Godot Radial Menu](https://github.com/tavurth/godot-radial-menu) - A radial menu written in shader code for performance.
+- [Godot RPG Components](https://godotrpgcomponents.xyz) - Contains pre-coded nodes and systems that are common in RPGs.
 - [Godot Shader Warmup](https://github.com/Koisuji02/GodotShaderWarmup) - Extension for pre-warming shaders at startup to prevent runtime stuttering caused by shader compilation (works well also integrated with [engine shader baker](https://docs.godotengine.org/en/stable/tutorials/performance/pipeline_compilations.html#shader-baker); see `report.pdf` in the repository to view results).
 - [Godot Spin Button](https://github.com/yudinikita/godot-spin-button) - Horizontal Selector with extended options.
 - [Godot SQLite](https://github.com/2shady4u/godot-sqlite) - GDNative wrapper for SQLite, making it possible to use SQLite databases as data storage in your project.


### PR DESCRIPTION
RPG Components 2D is a collection of reusable components for building 2D RPGs in Godot. The library was designed with the principal of Overwriting via Polymorphism in mind. This means that extending the nodes with your own custom code is intended. This will allow greater customization and gives you the oppurtunity to fine-tune them (if needed).

<img width="350" height="350" alt="image" src="https://github.com/user-attachments/assets/494575cb-4a8a-499f-8db5-7b7bcf005a0e" />

[Open in GitHub](https://github.com/MUmarShahbaz/Godot-RPG-Components)