### PR TITLE
Add Godot Project Doctor Mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [Gedis](https://github.com/NodotProject/Gedis) - In-memory, Redis-like key-value store for Godot.
 - [GedisQueue](https://github.com/NodotProject/GedisQueue) - A comprehensive job queue system for Godot, backed by Gedis.
 - [Godot Doctor](https://github.com/codevogel/godot_doctor) - A powerful validation plugin for Godot that catches errors in scenes and resources before they reach runtime. Also supports type validation for `PackedScene`s.
+- [Godot Project Doctor Mini](https://github.com/Vav-Labs/godot-project-doctor-mini) - Editor plugin that scans a project and generates Markdown and JSON diagnostic reports covering missing scripts, broken resource paths, oversized textures, heavy scenes, and export readiness.
 - [Godot Google Play Game Services](https://github.com/Iakobs/godot-play-game-services) - Integrate Google Play Games Services in your Godot game.
 - [godot-ink](https://github.com/paulloz/godot-ink) - A C# (Mono) plugin to integrate stories writen in [ink](https://github.com/inkle/ink), a scripting language for writing interactive narrative.
 - [Godot NDI](https://github.com/unvermuthet/godot-ndi) - Integrates the NDI® SDK with Godot.

--- a/README.md
+++ b/README.md
@@ -228,12 +228,12 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [Gedis](https://github.com/NodotProject/Gedis) - In-memory, Redis-like key-value store for Godot.
 - [GedisQueue](https://github.com/NodotProject/GedisQueue) - A comprehensive job queue system for Godot, backed by Gedis.
 - [Godot Doctor](https://github.com/codevogel/godot_doctor) - A powerful validation plugin for Godot that catches errors in scenes and resources before they reach runtime. Also supports type validation for `PackedScene`s.
-- [Godot Project Doctor Mini](https://github.com/Vav-Labs/godot-project-doctor-mini) - Editor plugin that scans a project and generates Markdown and JSON diagnostic reports covering missing scripts, broken resource paths, oversized textures, heavy scenes, and export readiness.
 - [Godot Google Play Game Services](https://github.com/Iakobs/godot-play-game-services) - Integrate Google Play Games Services in your Godot game.
 - [godot-ink](https://github.com/paulloz/godot-ink) - A C# (Mono) plugin to integrate stories writen in [ink](https://github.com/inkle/ink), a scripting language for writing interactive narrative.
 - [Godot NDI](https://github.com/unvermuthet/godot-ndi) - Integrates the NDI® SDK with Godot.
 - [godot-playfab](https://github.com/Structed/godot-playfab) - Use PlayFab as your game's cross-platform backend, with easy analytics.
 - [Godot Polygon 2D Fracture](https://github.com/SoloByte/godot-polygon2d-fracture) - Two simple scripts for fracturing and cutting polygons.
+- [Godot Project Doctor Mini](https://github.com/Vav-Labs/godot-project-doctor-mini) - Editor plugin that scans a project and generates Markdown and JSON diagnostic reports covering missing scripts, broken resource paths, oversized textures, heavy scenes, and export readiness.
 - [Godot Radial Menu](https://github.com/tavurth/godot-radial-menu) - A radial menu written in shader code for performance.
 - [Godot Shader Warmup](https://github.com/Koisuji02/GodotShaderWarmup) - Extension for pre-warming shaders at startup to prevent runtime stuttering caused by shader compilation (works well also integrated with [engine shader baker](https://docs.godotengine.org/en/stable/tutorials/performance/pipeline_compilations.html#shader-baker); see `report.pdf` in the repository to view results).
 - [Godot Spin Button](https://github.com/yudinikita/godot-spin-button) - Horizontal Selector with extended options.


### PR DESCRIPTION
Adds Godot Project Doctor Mini to the Plugins and scripts section (Godot 4).

- MIT licensed
- Pure GDScript, editor-only plugin
- Scans for missing scripts, broken resource paths, large textures, heavy scenes, export preset gaps, and import settings issues
- Generates Markdown and JSON reports; supports headless/CI use
- Requires Godot 4.6+
- Repository: https://github.com/Vav-Labs/godot-project-doctor-mini

Supersedes #469, which auto-closed after a force-push and can't be reopened. The entry is in correct alphabetical order (between Godot Polygon 2D Fracture and Godot Radial Menu). Earlier discussion — including the "mini" naming question (scope, not a paid upsell; there's no "full" version, free + MIT) — is on #469.
