### PR TITLE
Add Beckett - MCP for Godot (Plugins and scripts, Godot 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [AnimSheet](https://github.com/Lighar/AnimSheet) - Automatically generate AnimationPlayer or AnimatedSprite2D nodes directly from spritesheets within the Godot editor.
 - [AntialiasedLine2D](https://github.com/godot-extended-libraries/godot-antialiased-line2d) - Higher-quality antialiased Line2D and Polygon2D drawing compared to the default Godot implementation (all rendering methods, all platforms).
 - [Aseprite Wizard](https://github.com/viniciusgerevini/godot-aseprite-wizard) - Plugin for importing animations from Aseprite as SpriteFrames.
+- [Beckett — MCP for Godot](https://github.com/beckettlab/beckett-godot-mcp) - Zero-sidecar Model Context Protocol (MCP) server embedded in the editor, letting AI assistants inspect and edit scenes, scripts, and resources over local HTTP.
 - [Beehave](https://github.com/bitbrain/beehave) - Enables you to create robust NPC AI systems using behavior trees.
 - [CReverter (Composite Reverter)](https://codeberg.org/svetogam/creverter) - Memento-based undo/redo utility that supports composition.
 - [CSConnector (Contextual Signal/Setup Connector)](https://codeberg.org/svetogam/csconnector) - Provides a clean interface to dynamically find, setup, and connect to descendant nodes through the scene tree.


### PR DESCRIPTION
Adds **Beckett - MCP for Godot** under Plugins and scripts → Godot 4 (alphabetical, before Beehave).

A zero-sidecar [Model Context Protocol](https://modelcontextprotocol.io) server embedded in the Godot 4 editor as a GDScript `EditorPlugin`, so AI assistants can inspect and edit scenes, scripts, and resources over local HTTP. Free/libre: MIT licensed.

Repo: https://github.com/beckettlab/beckett-godot-mcp