### PR TITLE
Add Godot-MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [Godot Doctor](https://github.com/codevogel/godot_doctor) - A powerful validation plugin for Godot that catches errors in scenes and resources before they reach runtime. Also supports type validation for `PackedScene`s.
 - [Godot Google Play Game Services](https://github.com/Iakobs/godot-play-game-services) - Integrate Google Play Games Services in your Godot game.
 - [godot-ink](https://github.com/paulloz/godot-ink) - A C# (Mono) plugin to integrate stories writen in [ink](https://github.com/inkle/ink), a scripting language for writing interactive narrative.
+- [Godot-MCP](https://github.com/IvanMurzak/Godot-MCP) - Open-source MCP server connecting AI agents (Claude, Cursor, GitHub Copilot, Gemini, and more) to the Godot Editor and runtime (Godot 4.x, C#).
 - [Godot NDI](https://github.com/unvermuthet/godot-ndi) - Integrates the NDI® SDK with Godot.
 - [godot-playfab](https://github.com/Structed/godot-playfab) - Use PlayFab as your game's cross-platform backend, with easy analytics.
 - [Godot Polygon 2D Fracture](https://github.com/SoloByte/godot-polygon2d-fracture) - Two simple scripts for fracturing and cutting polygons.


### PR DESCRIPTION
Adds Godot-MCP, an open-source (Apache-2.0) MCP server that connects AI coding agents (Claude, Cursor, GitHub Copilot, Gemini, and others) to the Godot Editor and runtime via Anthropic's Model Context Protocol. Supports Godot 4.x (C#). Maintained at github.com/IvanMurzak/Godot-MCP. Happy to adjust formatting/placement to match this list's conventions — thanks for maintaining it!