### PR TITLE
Add Saltmire Transitions to Plugins and scripts (Godot 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [Quill-IDE](https://github.com/rayzorite/quill-ide) - Modified and beautified version of the default Godot Script Editor for 4.4+.
 - [Ridiculous Coding](https://github.com/jotson/ridiculous_coding) - Makes your coding experience in Godot 1000× more ridiculous.
 - [Roommate](https://github.com/hoork/roommate) - 3D level builder tool with focus on creating indoors environment and automation.
+- [Saltmire Transitions](https://github.com/saltmire/saltmire-transitions) - One-line scene transitions: fade, iris circle, directional wipes, and pixelate dissolve. Awaitable API, aspect-correct shaders, MIT.
 - [Scene Library](https://github.com/4d49/scene-library) - A tool for organizing Godot scenes with efficiency.
 - [Scene Manager](https://github.com/glass-brick/Scene-Manager) - Make nice and customizable scene transitions in one line of code. *(Godot 3 and 4)*
 - [Script-IDE](https://github.com/Maran23/script-ide) - Transforms the script editor into an IDE-like UI. Multiline tabs, improved outline, quick open and override, enhanced keyboard navigation.


### PR DESCRIPTION
Adds [Saltmire Transitions](https://github.com/saltmire/saltmire-transitions), a free (MIT) scene-transition manager for Godot 4: change scenes in one line with fade, iris circle, directional wipes, and a pixelate dissolve. Fully awaitable API (cover/reveal/to), aspect-correct shaders, drop-in autoload, no dependencies.

- License: MIT
- Sorted alphabetically under Plugins and scripts > Godot 4
- itch.io page (with preview GIF): https://saltmire.itch.io/saltmire-transitions-scene-transition-kit-for-godot-4