### PR TITLE
Add Saltmire Trail to Plugins and scripts (Godot 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [Quill-IDE](https://github.com/rayzorite/quill-ide) - Modified and beautified version of the default Godot Script Editor for 4.4+.
 - [Ridiculous Coding](https://github.com/jotson/ridiculous_coding) - Makes your coding experience in Godot 1000× more ridiculous.
 - [Roommate](https://github.com/hoork/roommate) - 3D level builder tool with focus on creating indoors environment and automation.
+- [Saltmire Trail](https://github.com/saltmire/saltmire-trail) - One-call 2D motion trails / afterimages: attach fading ghosts to any sprite for dashes, speed and juice. Free (MIT), no dependencies.
 - [Scene Library](https://github.com/4d49/scene-library) - A tool for organizing Godot scenes with efficiency.
 - [Scene Manager](https://github.com/glass-brick/Scene-Manager) - Make nice and customizable scene transitions in one line of code. *(Godot 3 and 4)*
 - [Script-IDE](https://github.com/Maran23/script-ide) - Transforms the script editor into an IDE-like UI. Multiline tabs, improved outline, quick open and override, enhanced keyboard navigation.


### PR DESCRIPTION
Adds [Saltmire Trail](https://github.com/saltmire/saltmire-trail), a free (MIT) one-call 2D motion-trail / afterimage tool for Godot 4. Attaches fading ghost copies to any Sprite2D / AnimatedSprite2D / TextureRect for dashes, speed and juice. Drop-in autoload, no dependencies. One line, alphabetical order, in Plugins and scripts → Godot 4.