### PR TITLE
Add Saltmire Save Lite to Plugins and scripts (Godot 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [Quill-IDE](https://github.com/rayzorite/quill-ide) - Modified and beautified version of the default Godot Script Editor for 4.4+.
 - [Ridiculous Coding](https://github.com/jotson/ridiculous_coding) - Makes your coding experience in Godot 1000× more ridiculous.
 - [Roommate](https://github.com/hoork/roommate) - 3D level builder tool with focus on creating indoors environment and automation.
+- [Saltmire Save Lite](https://github.com/saltmire/saltmire-save-lite) - One-line save/load for Godot 4: write/read/has/erase/list_slots/autosave in a single call. Drop-in autoload, zero dependencies, MIT.
 - [Scene Library](https://github.com/4d49/scene-library) - A tool for organizing Godot scenes with efficiency.
 - [Scene Manager](https://github.com/glass-brick/Scene-Manager) - Make nice and customizable scene transitions in one line of code. *(Godot 3 and 4)*
 - [Script-IDE](https://github.com/Maran23/script-ide) - Transforms the script editor into an IDE-like UI. Multiline tabs, improved outline, quick open and override, enhanced keyboard navigation.


### PR DESCRIPTION
One-line save/load for Godot 4 — write, read, has, erase, list_slots, autosave and stats in a single call. Drop-in autoload, zero dependencies, MIT. Ships a headless selftest (`selftest.gd`) that prints SELFTEST PASS.

Repo: https://github.com/saltmire/saltmire-save-lite

- [x] Free & open source (MIT)
- [x] Works with Godot 4 (tested 4.6)
- [x] Alphabetical order within the list
- [x] Single entry, one line