### PR TITLE
Add Forge Logger (in-game bug reporting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [Event Audio](https://github.com/bbbscarter/event-audio-godot) - A simple event-based "fire and forget" audio triggering system.
 - [Fast Fourier Transform (FFT)](https://github.com/tavurth/godot-fft) - Fast Fourier Transform in GDScript.
 - [FMOD GDNative](https://github.com/utopia-rise/fmod-gdnative) - Plugin to use the FMOD audio engine in GDScript.
+- [Forge Logger](https://github.com/stoneforgelabs/forge-logger-godot) - In-game bug reporting for Godot 4: players press a key to send a structured report with a screenshot, log and session context, plus an optional hosted dashboard for triage, AI summaries and issue-tracker export.
 - [friflo ECS](https://github.com/friflo/Friflo.Engine.ECS) - High-performance C# ECS with simple API. Supports .NET, WASM/WebAssembly, Native AOT, Godot, Unity, MonoGame, ... *(Godot 3 and 4)*
 - [func_godot](https://github.com/func-godot/func_godot_plugin) - Import maps using the [Quake MAP file format](https://quakewiki.org/wiki/Quake_Map_Format), commonly made using an editor such as [TrenchBroom](https://trenchbroom.github.io/).
 - [GATO: Godot Accessibility Toolkit](https://github.com/Nokorpo/gato-godot-accessibility-toolkit) - A collection of demos and addons to promote accessibility in Godot games.


### PR DESCRIPTION
Adds Forge Logger, an MIT-licensed in-game bug reporting plugin for Godot 4: players press a key to send a structured report (screenshot, log file, and the scene/build/environment it happened in), with an optional free hosted dashboard for triage, AI summaries and issue-tracker export. MIT licensed, on the Godot Asset Library:
https://godotengine.org/asset-library/asset/5321
Repo: https://github.com/stoneforgelabs/forge-logger-godot