### PR TITLE
Add Hera Agent Godot

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [GUT](https://github.com/bitwes/Gut) - Utility for writing unit tests in GDScript.
 - [HCoroutines](https://github.com/Inspiaaa/HCoroutines) - Powerful C# coroutine library for Godot.
 - [Health, HitBoxes, HurtBoxes, and HitScans](https://github.com/cluttered-code/godot-health-hitbox-hurtbox) - 2D and 3D Components to manage health, damage, and healing.
+- [Hera Agent Godot](https://github.com/NotNull92/hera-agent-godot) - Drive a live Godot editor from the command line: inspect scenes, edit nodes, run the game and read logs. Built for AI coding agents.
 - [HTerrain](https://github.com/Zylann/godot_heightmap_plugin) - Heightmap-based terrain. Supports texture painting, colouring, holes, level of detail and grass. *(Godot 3 and 4)*
 - [Icon Explorer](https://kenyoni-software.github.io/godot-addons/addons/icon_explorer) - Browse and save icons from popular icon collections.
 - [Importality](https://github.com/nklbdev/godot-4-importality) - raster graphics and animations importers: Aseprite, Krita, Pencil2D, Piskel, Pixelorama and others.


### PR DESCRIPTION
Adds [Hera Agent Godot](https://github.com/NotNull92/hera-agent-godot) to **Plugins and scripts → Godot 4** (alphabetical position, between "Health, HitBoxes, HurtBoxes, and HitScans" and "HTerrain").

Hera is an MIT-licensed editor addon plus companion CLI that lets scripts and AI coding agents drive a live Godot editor over localhost HTTP: inspect and mutate scenes (undoable), run/stop the game, read logs, and verify results. Supports Godot 4.2–4.7 (documented [support matrix](https://github.com/NotNull92/hera-agent-godot/blob/main/docs/SUPPORT_MATRIX.md)), with a [tested output contract](https://github.com/NotNull92/hera-agent-godot/blob/main/docs/CONTRACT.md) and CI on 4.2 + 4.7.

It is also published on the official [Godot Asset Store](https://store.godotengine.org/asset/notnull92/hera-agent-godot/).