### PR TITLE
Add Blobsmith Autotile Wirer (Godot 4 plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 - [AntialiasedLine2D](https://github.com/godot-extended-libraries/godot-antialiased-line2d) - Higher-quality antialiased Line2D and Polygon2D drawing compared to the default Godot implementation (all rendering methods, all platforms).
 - [Aseprite Wizard](https://github.com/viniciusgerevini/godot-aseprite-wizard) - Plugin for importing animations from Aseprite as SpriteFrames.
 - [Beehave](https://github.com/bitbrain/beehave) - Enables you to create robust NPC AI systems using behavior trees.
+- [Blobsmith Autotile Wirer](https://github.com/leobaray/blobsmith-autotile-wirer) - Turn a 47-blob autotile tilesheet into a fully wired TileSet (terrains, peering bits, collisions) in one click.
 - [CReverter (Composite Reverter)](https://codeberg.org/svetogam/creverter) - Memento-based undo/redo utility that supports composition.
 - [CSConnector (Contextual Signal/Setup Connector)](https://codeberg.org/svetogam/csconnector) - Provides a clean interface to dynamically find, setup, and connect to descendant nodes through the scene tree.
 - [CSLocator (Contextual Service Locator)](https://codeberg.org/svetogam/cslocator) - Provides a clean interface to register and find objects through the scene tree like localized singletons.


### PR DESCRIPTION
Adds [Blobsmith Autotile Wirer](https://github.com/leobaray/blobsmith-autotile-wirer) under Plugins and scripts → Godot 4 (alphabetical position after Beehave).

- Editor plugin that turns a 47-blob (or 16-tile) autotile tilesheet into a fully wired `TileSet`: terrain set, peering bits on all tiles, optional collision shapes.
- MIT licensed; approved on the official Godot Asset Library ([asset #5343](https://godotengine.org/asset-library/asset/5343)).
- Verified against Godot 4.7 stable with a headless test suite included in the repo.