### PR TITLE
Add Civic Nightmare to Godot 4 2D games

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 
 - [99Managers Futsal Edition](https://codeberg.org/dulvui/99managers-futsal-edition) - A simple free/libre Futsal team-management game.
 - [A Dark Forest](https://github.com/TinyTakinTeller/GodotProjectZero) - Minimalistic incremental game inspired by "A Dark Room".
+- [Civic Nightmare](https://github.com/Daniele-Cangi/civic-nightmare) - Satirical top-down bureaucracy RPG with MIT-licensed Godot source code and separately documented media rights.
 - [Librerama](https://codeberg.org/Yeldham/librerama) - A free/libre fast-paced arcade collection of mini-games.
 - [Poder Solar](https://codeberg.org/antimundo/poder-solar) - Simple resource management game.
 - [Unknown Horizons](https://github.com/unknown-horizons/godot-port) - Official work-in-progress reimplementation of Unknown Horizons.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See [Vivraan/godot-lang-support](https://github.com/Vivraan/godot-lang-support).
 
 - [99Managers Futsal Edition](https://codeberg.org/dulvui/99managers-futsal-edition) - A simple free/libre Futsal team-management game.
 - [A Dark Forest](https://github.com/TinyTakinTeller/GodotProjectZero) - Minimalistic incremental game inspired by "A Dark Room".
-- [Civic Nightmare](https://github.com/Daniele-Cangi/civic-nightmare) - Satirical top-down bureaucracy RPG with MIT-licensed Godot source code and separately documented media rights.
+- [Civic Nightmare](https://github.com/Daniele-Cangi/civic-nightmare) - Satirical top-down bureaucracy RPG (MIT). Asset licensing details: [ASSET_NOTICE.md](https://github.com/Daniele-Cangi/civic-nightmare/blob/main/ASSET_NOTICE.md)
 - [Librerama](https://codeberg.org/Yeldham/librerama) - A free/libre fast-paced arcade collection of mini-games.
 - [Poder Solar](https://codeberg.org/antimundo/poder-solar) - Simple resource management game.
 - [Unknown Horizons](https://github.com/unknown-horizons/godot-port) - Official work-in-progress reimplementation of Unknown Horizons.


### PR DESCRIPTION
Adds [Civic Nightmare](https://github.com/Daniele-Cangi/civic-nightmare) to **Games → 2D → Godot 4**.

Civic Nightmare is a playable top-down political-satire RPG built with Godot 4.6. Its source code and software implementation are MIT-licensed. The repository deliberately documents the separate rights and provenance boundary for existing media and narrative content in [`ASSET_NOTICE.md`](https://github.com/Daniele-Cangi/civic-nightmare/blob/main/ASSET_NOTICE.md).

I am calling out that boundary explicitly because this list requires free/libre licensing. If eligibility requires every shipped media and narrative asset—not only the complete software implementation—to carry a free-culture license, I understand that the project may not qualify.

The change adds one alphabetically sorted entry and preserves the existing format.
